### PR TITLE
Support for s1c and s1d satellites

### DIFF
--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -74,7 +74,7 @@ def create_collection(json_path: str) -> pystac.Collection:
 
     # Item Asset Extension
     assets = ItemAssetsExtension.ext(collection, add_if_missing=True)
-    assets.item_assets = c.SENTINEL_GRD_ASSETS
+    assets.item_assets = c.SENTINEL_GRD_ASSETS  # type: ignore
 
     return collection
 

--- a/src/stactools/sentinel1/metadata_links.py
+++ b/src/stactools/sentinel1/metadata_links.py
@@ -20,7 +20,7 @@ class ManifestError(Exception):
 
 dataset_naming_pattern = re.compile(
     "^.*"
-    + "(?P<mission>s1a|s1b)"
+    + "(?P<mission>s1a|s1b|s1c|s1d)"
     + "-(?P<swath>s[1-6]|iw[1-3]?|ew[1-5]?|wv[1-2]|en|n[1-6]|is[1-7])"
     + "-(?P<type>slc|grd)"
     + "-(?P<polarisation>hh|hv|vv|vh)"

--- a/src/stactools/sentinel1/slc/stac.py
+++ b/src/stactools/sentinel1/slc/stac.py
@@ -80,7 +80,7 @@ def create_collection(json_path: str) -> pystac.Collection:
 
     # Item Asset Extension
     assets = ItemAssetsExtension.ext(collection, add_if_missing=True)
-    assets.item_assets = c.SENTINEL_SLC_ASSETS
+    assets.item_assets = c.SENTINEL_SLC_ASSETS  # type: ignore
 
     return collection
 


### PR DESCRIPTION
Following  [PR#62](https://github.com/stactools-packages/sentinel1/pull/62) on main sentinel1 repository:

**Description:**
This PR add support for s1c and future s1d satellites.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
